### PR TITLE
Server timing header

### DIFF
--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -55,14 +55,11 @@ export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrum
     }
 
     exposedSuper._endSpan = (span, performanceName, entries) => {
-      const transactionTraceId = impl.getTransactionTraceId();
 
-      if(transactionTraceId) {
-        const transactionSpan = impl.getTransactionSpan();
-        // Don't close transactionSpan
-        // transactionSpan will be closed through "beforeunload"-event
-        if(transactionSpan && transactionSpan == span) return;
-      }
+      const transactionSpan = impl.getTransactionSpan();
+      // Don't close transactionSpan
+      // transactionSpan will be closed through "beforeunload"-event
+      if(transactionSpan && transactionSpan == span) return;
 
       return _superEndSpan(span, performanceName, entries);
     };

--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -42,7 +42,8 @@ export function patchTracer(impl: OpenTelemetryTracingImpl) {
         parentContext = transactionSpan.spanContext();
     }
 
-    const spanId = this._idGenerator.generateSpanId();
+    // Use provided transaction span-ID for documentLoadSpan
+    const spanId = name == "documentLoad" ? impl.getTransactionSpanId() : this._idGenerator.generateSpanId();
     let traceId;
     let traceState;
     let parentSpanId;

--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -16,7 +16,8 @@ import { FetchInstrumentation, FetchInstrumentationConfig } from '@opentelemetry
 import { createContextKey } from '@opentelemetry/api';
 
 export interface DocumentLoadServerTimingInstrumentationConfig extends InstrumentationConfig {
-  serverTiming?: boolean;
+  recordTransaction?: boolean;
+  exporterDelay?: number;
 }
 
 type PerformanceEntriesWithServerTiming = PerformanceEntries & {serverTiming?: ReadonlyArray<({name: string, duration: number, description: string})>}

--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -161,10 +161,10 @@ export class PatchedFetchInstrumentation extends FetchInstrumentation {
       const spanName = `HTTP ${method}`;
 
       let activeContext = api.context.active();
-      let contextKey = Symbol.for("OpenTelemetry Context Key SPAN");
+      let contextKey = createContextKey("OpenTelemetry Context Key SPAN");
       let activeSpan = activeContext.getValue(contextKey);
 
-      // XMLHttpRequestInstrumentation does not find transactionSpan via api.context().active()
+      // FetchInstrumentation does not find transactionSpan via api.context().active()
       if(!activeSpan) {
         const transactionSpan = impl.getTransactionSpan()
         activeContext = api.trace.setSpan(api.context.active(), transactionSpan);

--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -42,8 +42,13 @@ export function patchTracer() {
         parentContext = transactionSpan.spanContext();
     }
 
-    // Use provided transaction span-ID for documentLoadSpan
-    const spanId = name == "documentLoad" ? TransactionSpanManager.getTransactionSpanId() : this._idGenerator.generateSpanId();
+    // Use transaction span-ID for documentLoadSpan, if existing
+    let spanId = this._idGenerator.generateSpanId();
+    if(name == "documentLoad") {
+      const transactionSpanId = TransactionSpanManager.getTransactionSpanId();
+      if(transactionSpanId) spanId = transactionSpanId;
+    }
+
     let traceId;
     let traceState;
     let parentSpanId;

--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -1,37 +1,19 @@
 // Also see: https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/SplunkDocumentLoadInstrumentation.ts
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
-import * as api from '@opentelemetry/api';
 import { captureTraceParentFromPerformanceEntries } from './servertiming';
-import { hasKey, PerformanceEntries } from '@opentelemetry/sdk-trace-web';
+import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
 import { Span } from '@opentelemetry/sdk-trace-base';
-import { isUrlIgnored } from '@opentelemetry/core';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { context, trace } from '@opentelemetry/api';
-import { AttributeNames } from '@opentelemetry/instrumentation-document-load/build/esm/enums/AttributeNames';
 import OpenTelemetryTracingImpl from './index'
 
 export interface DocumentLoadServerTimingInstrumentationConfig extends InstrumentationConfig {
   ignoreUrls?: (string|RegExp)[];
 }
 
-const excludedInitiatorTypes = ['beacon', 'fetch', 'xmlhttprequest'];
-
-function addExtraDocLoadTags(span: api.Span) {
-  if (document.referrer && document.referrer !== '') {
-    span.setAttribute('document.referrer', document.referrer);
-  }
-  if (window.screen) {
-    span.setAttribute('screen.xy', window.screen.width + 'x' + window.screen.height);
-  }
-}
-
 type PerformanceEntriesWithServerTiming = PerformanceEntries & {serverTiming?: ReadonlyArray<({name: string, duration: number, description: string})>}
 
 type ExposedSuper = {
   _startSpan(spanName: string, performanceName: string, entries: PerformanceEntries, parentSpan?: Span): void;
-  _endSpan(span: api.Span | undefined, performanceName: string, entries: PerformanceEntries): void;
-  _initResourceSpan(resource: PerformanceResourceTiming, parentSpan: api.Span): void;
 }
 
 export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrumentation {
@@ -47,7 +29,6 @@ export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrum
 
     const _superStartSpan: ExposedSuper['_startSpan'] = exposedSuper._startSpan.bind(this);
     exposedSuper._startSpan = (spanName, performanceName, entries, parentSpan) => {
-
       if (
         !(entries as PerformanceEntriesWithServerTiming).serverTiming &&
         performance.getEntriesByType
@@ -60,54 +41,9 @@ export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrum
         }
       }
 
-      // TODO neue Funktion schreiben ohne Span
-      captureTraceParentFromPerformanceEntries(entries, null, impl);
+      captureTraceParentFromPerformanceEntries(entries, impl);
 
       return _superStartSpan(spanName, performanceName, entries, parentSpan);
     }
-
-
-    const _superEndSpan: ExposedSuper['_endSpan'] = exposedSuper._endSpan.bind(this);
-    exposedSuper._endSpan = (span, performanceName, entries) => {
-      const exposedSpan = span as any as Span;
-
-      if (span) {
-        span.setAttribute('component', this.component);
-      }
-
-      if (span && exposedSpan.name !== 'documentLoad') { // only apply links to document/resource fetch
-        // To maintain compatibility, getEntries copies out select items from
-        // different versions of the performance API into its own structure for the
-        // initial document load (but leaves the entries undisturbed for resource loads).
-        if (
-          exposedSpan.name === 'documentFetch' &&
-          !(entries as PerformanceEntriesWithServerTiming).serverTiming &&
-          performance.getEntriesByType
-        ) {
-          const navEntries = performance.getEntriesByType('navigation');
-            // @ts-ignore
-          if (navEntries[0]?.serverTiming) {
-            // @ts-ignore
-            (entries as PerformanceEntriesWithServerTiming).serverTiming = navEntries[0].serverTiming;
-          }
-        }
-
-        captureTraceParentFromPerformanceEntries(entries, span, impl);
-        span.setAttribute(SemanticAttributes.HTTP_METHOD, 'GET');
-      }
-      if (span && exposedSpan.name === 'documentLoad') {
-        addExtraDocLoadTags(span);
-      }
-      return _superEndSpan(span, performanceName, entries);
-    };
-
-    const _superInitResourceSpan: ExposedSuper['_initResourceSpan'] = exposedSuper._initResourceSpan.bind(this);
-    exposedSuper._initResourceSpan = (resource, parentSpan) => {
-      if (excludedInitiatorTypes.indexOf(resource.initiatorType) !== -1 || isUrlIgnored(resource.name, config.ignoreUrls)) {
-        return;
-      }
-      _superInitResourceSpan(resource, parentSpan);
-    };
-
   }
 }

--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -1,0 +1,83 @@
+// Also see: https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/SplunkDocumentLoadInstrumentation.ts
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
+import * as api from '@opentelemetry/api';
+import { captureTraceParentFromPerformanceEntries } from './servertiming';
+import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
+import { Span } from '@opentelemetry/sdk-trace-base';
+import { isUrlIgnored } from '@opentelemetry/core';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+
+export interface DocumentLoadServerTimingInstrumentationConfig extends InstrumentationConfig {
+  ignoreUrls?: (string|RegExp)[];
+}
+
+const excludedInitiatorTypes = ['beacon', 'fetch', 'xmlhttprequest'];
+
+function addExtraDocLoadTags(span: api.Span) {
+  if (document.referrer && document.referrer !== '') {
+    span.setAttribute('document.referrer', document.referrer);
+  }
+  if (window.screen) {
+    span.setAttribute('screen.xy', window.screen.width + 'x' + window.screen.height);
+  }
+}
+
+type PerformanceEntriesWithServerTiming = PerformanceEntries & {serverTiming?: ReadonlyArray<({name: string, duration: number, description: string})>}
+
+type ExposedSuper = {
+  _endSpan(span: api.Span | undefined, performanceName: string, entries: PerformanceEntries): void;
+  _initResourceSpan(resource: PerformanceResourceTiming, parentSpan: api.Span): void;
+}
+
+export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrumentation {
+  constructor(config: DocumentLoadServerTimingInstrumentationConfig = {}) {
+    super(config);
+
+    const exposedSuper = this as any as ExposedSuper;
+
+    const _superEndSpan: ExposedSuper['_endSpan'] = exposedSuper._endSpan.bind(this);
+    exposedSuper._endSpan = (span, performanceName, entries) => {
+      // TODO: upstream exposed name on api.Span, then fix
+      const exposedSpan = span as any as Span;
+
+      if (span) {
+        span.setAttribute('component', this.component);
+      }
+
+      if (span && exposedSpan.name !== 'documentLoad') { // only apply links to document/resource fetch
+        // To maintain compatibility, getEntries copies out select items from
+        // different versions of the performance API into its own structure for the
+        // initial document load (but leaves the entries undisturbed for resource loads).
+        if (
+          exposedSpan.name === 'documentFetch' &&
+          !(entries as PerformanceEntriesWithServerTiming).serverTiming &&
+          performance.getEntriesByType
+        ) {
+          const navEntries = performance.getEntriesByType('navigation');
+            // @ts-ignore
+          if (navEntries[0]?.serverTiming) {
+            // @ts-ignore
+            (entries as PerformanceEntriesWithServerTiming).serverTiming = navEntries[0].serverTiming;
+          }
+        }
+
+        captureTraceParentFromPerformanceEntries(entries, span);
+        span.setAttribute(SemanticAttributes.HTTP_METHOD, 'GET');
+      }
+      if (span && exposedSpan.name === 'documentLoad') {
+        addExtraDocLoadTags(span);
+      }
+      return _superEndSpan(span, performanceName, entries);
+    };
+
+    const _superInitResourceSpan: ExposedSuper['_initResourceSpan'] = exposedSuper._initResourceSpan.bind(this);
+    exposedSuper._initResourceSpan = (resource, parentSpan) => {
+      if (excludedInitiatorTypes.indexOf(resource.initiatorType) !== -1 || isUrlIgnored(resource.name, config.ignoreUrls)) {
+        return;
+      }
+      _superInitResourceSpan(resource, parentSpan);
+    };
+
+  }
+}

--- a/src/impl/documentLoadInstrumentation.ts
+++ b/src/impl/documentLoadInstrumentation.ts
@@ -1,6 +1,7 @@
 // Also see: https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/SplunkDocumentLoadInstrumentation.ts
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
+import * as api from '@opentelemetry/api';
 import { captureTraceParentFromPerformanceEntries } from './servertiming';
 import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
 import { Span } from '@opentelemetry/sdk-trace-base';
@@ -10,10 +11,20 @@ export interface DocumentLoadServerTimingInstrumentationConfig extends Instrumen
   ignoreUrls?: (string|RegExp)[];
 }
 
+function addExtraDocLoadTags(span: api.Span) {
+  if (document.referrer && document.referrer !== '') {
+    span.setAttribute('document.referrer', document.referrer);
+  }
+  if (window.screen) {
+    span.setAttribute('screen.xy', window.screen.width + 'x' + window.screen.height);
+  }
+}
+
 type PerformanceEntriesWithServerTiming = PerformanceEntries & {serverTiming?: ReadonlyArray<({name: string, duration: number, description: string})>}
 
 type ExposedSuper = {
-  _startSpan(spanName: string, performanceName: string, entries: PerformanceEntries, parentSpan?: Span): void;
+  _startSpan(spanName: string, performanceName: string, entries: PerformanceEntries, parentSpan?: Span): api.Span | undefined;
+  _endSpan(span: api.Span | undefined, performanceName: string, entries: PerformanceEntries): void;
 }
 
 export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrumentation {
@@ -25,7 +36,6 @@ export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrum
     super(config);
 
     const exposedSuper = this as any as ExposedSuper;
-
 
     const _superStartSpan: ExposedSuper['_startSpan'] = exposedSuper._startSpan.bind(this);
     exposedSuper._startSpan = (spanName, performanceName, entries, parentSpan) => {
@@ -40,10 +50,30 @@ export class DocumentLoadServerTimingInstrumentation extends DocumentLoadInstrum
           (entries as PerformanceEntriesWithServerTiming).serverTiming = navEntries[0].serverTiming;
         }
       }
-
       captureTraceParentFromPerformanceEntries(entries, impl);
 
-      return _superStartSpan(spanName, performanceName, entries, parentSpan);
+      const span = _superStartSpan(spanName, performanceName, entries, parentSpan);
+
+      if(parentSpan == null) {
+        const transactionSpanId = span.spanContext().spanId;
+        impl.setTransactionSpanId(transactionSpanId);
+      }
+
+      return span;
     }
+
+    const _superEndSpan: ExposedSuper['_endSpan'] = exposedSuper._endSpan.bind(this);
+    exposedSuper._endSpan = (span, performanceName, entries) => {
+
+      const transactionTraceId = impl.getTransactionTraceId();
+      if(transactionTraceId) {
+        const transactionSpanId = impl.getTransactionSpanId();
+        const currentSpanId = span.spanContext().spanId;
+        //Don't close current span, if it's the transaction span
+        //if(transactionSpanId && transactionSpanId == currentSpanId) return;
+      }
+
+      return _superEndSpan(span, performanceName, entries);
+    };
   }
 }

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -109,6 +109,7 @@ export default class OpenTelemetryTracingImpl {
   private customSpanProcessor = new CustomSpanProcessor();
   private customIdGenerator = new CustomIdGenerator(this);
   private traceId: string;
+  private spanId: string;
 
   public register = () => {
     // return if already initialized
@@ -209,7 +210,21 @@ export default class OpenTelemetryTracingImpl {
     console.info("TraceID set " + traceId);
   }
 
+  public getTransactionSpanId = () => {
+    return this.spanId;
+  }
+
+  public setTransactionSpanId = (spanId: string) => {
+    this.spanId = spanId;
+  }
+
   public startNewTransaction = () => {
+    // const testSpan = api.trace.getTracer('my-awesome-tracer').startSpan('awesome-trace');
+    // window.addEventListener("beforeunload", () => {
+    //   //FUNCT NICHT...
+    //   testSpan.end();
+    //   testSpan.isRecording();
+    // })
     this.traceId = null;
     const newTraceId = this.customIdGenerator.generateTraceId();
     this.traceId = newTraceId;

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -219,24 +219,25 @@ export default class OpenTelemetryTracingImpl {
 
   public setTransactionSpan = (span: Span) => {
     this.transactionSpan = span;
-    console.info("Context set " + span);
+    console.info("Span set");
+    console.info(span);
 
-    window.addEventListener("beforeunload", () => {
+    window.addEventListener("beforeunload", (event) => {
       this.transactionSpan.end();
       this.traceProvider.forceFlush();
-      //Noch kurzer setTimeout() ?
-      setTimeout(function() {}, 500);
+      //This is necessary so the last span can be exported successfully
+      this.sleep(50);
     });
   }
 
+  private sleep(delay: number): void {
+    const start = new Date().getTime();
+    while (new Date().getTime() < start + delay);
+  }
+
   public startNewTransaction = () => {
-    // const testSpan = api.trace.getTracer('my-awesome-tracer').startSpan('awesome-trace');
-    // window.addEventListener("beforeunload", () => {
-    //   //FUNCT NICHT...
-    //   testSpan.end();
-    //   testSpan.isRecording();
-    // })
     this.traceId = null;
+    this.transactionSpan = null;
     const newTraceId = this.customIdGenerator.generateTraceId();
     this.traceId = newTraceId;
   }

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -33,7 +33,7 @@ import { patchExporter, patchExporterClass } from './patchCollectorPrototype';
 import { MultiSpanProcessor, CustomSpanProcessor } from './spanProcessing';
 import {
   DocumentLoadServerTimingInstrumentation, PatchedFetchInstrumentation,
-  PatchedUserInteractionInstrumentation, PatchedXMLHttpRequestInstrumentation
+  PatchedUserInteractionInstrumentation, PatchedXMLHttpRequestInstrumentation, patchTracer
 } from './documentLoadInstrumentation';
 import { CustomIdGenerator } from './transactionIdGeneration';
 
@@ -119,6 +119,8 @@ export default class OpenTelemetryTracingImpl {
 
     // instrument the tracer class for injecting default attributes
     this.instrumentTracerClass();
+
+    patchTracer();
 
     // the configuration used by the tracer
     const tracerConfiguration: WebTracerConfig = {

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -107,7 +107,7 @@ export default class OpenTelemetryTracingImpl {
   private traceProvider: WebTracerProvider;
 
   private customSpanProcessor = new CustomSpanProcessor();
-
+  private customIdGenerator = new CustomIdGenerator(this);
   private traceID: string;
 
   public register = () => {
@@ -122,7 +122,7 @@ export default class OpenTelemetryTracingImpl {
     // the configuration used by the tracer
     const tracerConfiguration: WebTracerConfig = {
       sampler: this.resolveSampler(),
-      idGenerator: new CustomIdGenerator(this),
+      idGenerator: this.customIdGenerator
     };
 
     // create provider
@@ -202,6 +202,7 @@ export default class OpenTelemetryTracingImpl {
 
   public setTraceID = (traceID: string) => {
     this.traceID = traceID;
+    this.customIdGenerator.setTraceID(traceID)
     console.info("TraceID set " + traceID);
   }
 

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -122,7 +122,7 @@ export default class OpenTelemetryTracingImpl {
     // the configuration used by the tracer
     const tracerConfiguration: WebTracerConfig = {
       sampler: this.resolveSampler(),
-      idGenerator: new CustomIdGenerator(),
+      idGenerator: new CustomIdGenerator(this),
     };
 
     // create provider

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -1,4 +1,4 @@
-import api, { context, trace, Span } from '@opentelemetry/api';
+import api, { context, trace, Span, SpanContext } from '@opentelemetry/api';
 import {
   AlwaysOnSampler,
   AlwaysOffSampler,
@@ -109,7 +109,7 @@ export default class OpenTelemetryTracingImpl {
   private customSpanProcessor = new CustomSpanProcessor();
   private customIdGenerator = new CustomIdGenerator(this);
   private traceId: string;
-  private spanId: string;
+  private transactionSpan: Span;
 
   public register = () => {
     // return if already initialized
@@ -210,12 +210,17 @@ export default class OpenTelemetryTracingImpl {
     console.info("TraceID set " + traceId);
   }
 
-  public getTransactionSpanId = () => {
-    return this.spanId;
+  public getTransactionSpan = () => {
+    return this.transactionSpan;
   }
 
-  public setTransactionSpanId = (spanId: string) => {
-    this.spanId = spanId;
+  public setTransactionSpan = (span: Span) => {
+    this.transactionSpan = span;
+    console.info("Context set " + span);
+
+    window.addEventListener("beforeunload", () => {
+      this.transactionSpan.end();
+    });
   }
 
   public startNewTransaction = () => {

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -31,6 +31,7 @@ import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-u
 import { PluginProperties, ContextFunction, PropagationHeader } from '../types';
 import { patchExporter, patchExporterClass } from './patchCollectorPrototype';
 import { MultiSpanProcessor, CustomSpanProcessor } from './spanProcessing';
+import { DocumentLoadServerTimingInstrumentation } from './documentLoadInstrumentation';
 
 /**
  * TODOs:
@@ -47,6 +48,7 @@ export default class OpenTelemetryTracingImpl {
       instrument_fetch: true,
       instrument_xhr: true,
       instrument_document_load: true,
+      instrument_document_load_server_timing: true,
       instrument_user_interaction: true,
     },
     plugins_config: {
@@ -69,6 +71,11 @@ export default class OpenTelemetryTracingImpl {
       instrument_document_load: {
         enabled: false,
         path: "",
+      },
+      instrument_document_load_server_timing: {
+        enabled: false,
+        path: "",
+        ignoreUrls: []
       },
       instrument_user_interaction: {
         enabled: false,
@@ -293,6 +300,14 @@ export default class OpenTelemetryTracingImpl {
     }
     else if (plugins?.instrument_document_load !== false) {
       instrumentations.push(new DocumentLoadInstrumentation());
+    }
+
+    // Instrumentation for document on load (initial request) with server timings
+    if (plugins_config?.instrument_document_load_server_timing?.enabled !== false) {
+      instrumentations.push(new DocumentLoadServerTimingInstrumentation(plugins_config.instrument_document_load_server_timing));
+    }
+    else if (plugins?.instrument_document_load_server_timing !== false) {
+      instrumentations.push(new DocumentLoadServerTimingInstrumentation());
     }
 
     // Instrumentation for user interactions

--- a/src/impl/index.ts
+++ b/src/impl/index.ts
@@ -32,7 +32,7 @@ import { PluginProperties, ContextFunction, PropagationHeader } from '../types';
 import { patchExporter, patchExporterClass } from './patchCollectorPrototype';
 import { MultiSpanProcessor, CustomSpanProcessor } from './spanProcessing';
 import { DocumentLoadServerTimingInstrumentation } from './documentLoadInstrumentation';
-import { CustomIdGenerator } from './traceIdGeneration';
+import { CustomIdGenerator } from './transactionIdGeneration';
 
 /**
  * TODOs:
@@ -108,7 +108,7 @@ export default class OpenTelemetryTracingImpl {
 
   private customSpanProcessor = new CustomSpanProcessor();
   private customIdGenerator = new CustomIdGenerator(this);
-  private traceID: string;
+  private traceId: string;
 
   public register = () => {
     // return if already initialized
@@ -200,14 +200,19 @@ export default class OpenTelemetryTracingImpl {
     this.customSpanProcessor.addCustomAttribute(key,value);
   }
 
-  public setTraceID = (traceID: string) => {
-    this.traceID = traceID;
-    this.customIdGenerator.setTraceID(traceID)
-    console.info("TraceID set " + traceID);
+  public getTransactionTraceId = () => {
+    return this.traceId;
   }
 
-  public getTraceID = () => {
-    return this.traceID;
+  public setTransactionTraceId = (traceId: string) => {
+    this.traceId = traceId;
+    console.info("TraceID set " + traceId);
+  }
+
+  public startNewTransaction = () => {
+    this.traceId = null;
+    const newTraceId = this.customIdGenerator.generateTraceId();
+    this.traceId = newTraceId;
   }
 
   public setBeaconUrl = (url: string) => {

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -7,8 +7,8 @@ function addMatchToSpan(match: RegExpMatchArray, span: Span, impl: OpenTelemetry
   if (match && match[1] && match[2]) {
     const traceId = match[1];
     const spanId = match[2];
-    span.setAttribute('link.traceId', traceId);
-    span.setAttribute('link.spanId', spanId);
+    //span.setAttribute('link.traceId', traceId);
+    //span.setAttribute('link.spanId', spanId);
     impl.setTraceID(traceId);
   }
 }

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -1,26 +1,26 @@
 // Also see: https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/servertiming.ts
 import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
-import OpenTelemetryTracingImpl from './index'
+import { TransactionSpanManager } from './transactionSpanManager';
 
-function setTransactionIds(match: RegExpMatchArray, impl: OpenTelemetryTracingImpl): void {
+function setTransactionIds(match: RegExpMatchArray): void {
   if (match && match[1] && match[2]) {
     const traceId = match[1];
     const spanId = match[2];
-    impl.setTransactionTraceId(traceId);
-    impl.setTransactionSpanId(spanId);
+    TransactionSpanManager.setTransactionTraceId(traceId);
+    TransactionSpanManager.setTransactionSpanId(spanId);
   }
 }
 
 const ValueRegex = new RegExp('00-([0-9a-f]{32})-([0-9a-f]{16})-01');
 
-export function captureTraceParentFromPerformanceEntries(entries: PerformanceEntries, impl: OpenTelemetryTracingImpl): void {
+export function captureTraceParentFromPerformanceEntries(entries: PerformanceEntries): void {
   if (!(entries as any).serverTiming) {
     return;
   }
   for(const st of (entries as any).serverTiming) {
     if (st.name === 'traceparent' && st.description) {
       const match = st.description.match(ValueRegex);
-      setTransactionIds(match, impl);
+      setTransactionIds(match);
     }
   }
 }

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -1,0 +1,40 @@
+// Also see: https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/servertiming.ts
+import { Span } from '@opentelemetry/api';
+import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
+
+function addMatchToSpan(match: RegExpMatchArray, span: Span): void {
+  if (match && match[1] && match[2]) {
+    const traceId = match[1];
+    const spanId = match[2];
+    span.setAttribute('link.traceId', traceId);
+    span.setAttribute('link.spanId', spanId);
+  }
+}
+
+const HeaderRegex = new RegExp('traceparent;desc=[\'"]00-([0-9a-f]{32})-([0-9a-f]{16})-01[\'"]');
+
+export function captureTraceParent(serverTimingValues: string, span: Span): void {
+  // getResponseHeader returns multiple Server-Timing headers concat with ', ' (note space)
+  // fetch returns concat with ','.
+  // split the difference
+  for(let header of serverTimingValues.split(',')) {
+    header = header.trim();
+    const match = header.match(HeaderRegex);
+    addMatchToSpan(match, span);
+  }
+}
+
+const ValueRegex = new RegExp('00-([0-9a-f]{32})-([0-9a-f]{16})-01');
+
+// TODO: fix types for ServerTiming from Performance
+export function captureTraceParentFromPerformanceEntries(entries: PerformanceEntries, span: Span): void {
+  if (!(entries as any).serverTiming) {
+    return;
+  }
+  for(const st of (entries as any).serverTiming) {
+    if (st.name === 'traceparent' && st.description) {
+      const match = st.description.match(ValueRegex);
+      addMatchToSpan(match, span);
+    }
+  }
+}

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -2,11 +2,12 @@
 import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
 import OpenTelemetryTracingImpl from './index'
 
-function setTransactionId(match: RegExpMatchArray, impl: OpenTelemetryTracingImpl): void {
+function setTransactionIds(match: RegExpMatchArray, impl: OpenTelemetryTracingImpl): void {
   if (match && match[1] && match[2]) {
     const traceId = match[1];
     const spanId = match[2];
-    if(traceId) impl.setTransactionTraceId(traceId);
+    impl.setTransactionTraceId(traceId);
+    impl.setTransactionSpanId(spanId);
   }
 }
 
@@ -19,7 +20,7 @@ export function captureTraceParentFromPerformanceEntries(entries: PerformanceEnt
   for(const st of (entries as any).serverTiming) {
     if (st.name === 'traceparent' && st.description) {
       const match = st.description.match(ValueRegex);
-      setTransactionId(match, impl);
+      setTransactionIds(match, impl);
     }
   }
 }

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -1,5 +1,4 @@
 // Also see: https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/servertiming.ts
-import { Span } from '@opentelemetry/api';
 import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
 import OpenTelemetryTracingImpl from './index'
 

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -2,7 +2,7 @@
 import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
 import OpenTelemetryTracingImpl from './index'
 
-function addMatchToSpan(match: RegExpMatchArray, impl: OpenTelemetryTracingImpl): void {
+function setTransactionId(match: RegExpMatchArray, impl: OpenTelemetryTracingImpl): void {
   if (match && match[1] && match[2]) {
     const traceId = match[1];
     const spanId = match[2];
@@ -19,7 +19,7 @@ export function captureTraceParentFromPerformanceEntries(entries: PerformanceEnt
   for(const st of (entries as any).serverTiming) {
     if (st.name === 'traceparent' && st.description) {
       const match = st.description.match(ValueRegex);
-      addMatchToSpan(match, impl);
+      setTransactionId(match, impl);
     }
   }
 }

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -3,26 +3,24 @@ import { Span } from '@opentelemetry/api';
 import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
 import OpenTelemetryTracingImpl from './index'
 
-function addMatchToSpan(match: RegExpMatchArray, span: Span, impl: OpenTelemetryTracingImpl): void {
+function addMatchToSpan(match: RegExpMatchArray, impl: OpenTelemetryTracingImpl): void {
   if (match && match[1] && match[2]) {
     const traceId = match[1];
     const spanId = match[2];
-    //span.setAttribute('link.traceId', traceId);
-    //span.setAttribute('link.spanId', spanId);
-    impl.setTraceID(traceId);
+    impl.setTransactionTraceId(traceId);
   }
 }
 
 const ValueRegex = new RegExp('00-([0-9a-f]{32})-([0-9a-f]{16})-01');
 
-export function captureTraceParentFromPerformanceEntries(entries: PerformanceEntries, span: Span, impl: OpenTelemetryTracingImpl): void {
+export function captureTraceParentFromPerformanceEntries(entries: PerformanceEntries, impl: OpenTelemetryTracingImpl): void {
   if (!(entries as any).serverTiming) {
     return;
   }
   for(const st of (entries as any).serverTiming) {
     if (st.name === 'traceparent' && st.description) {
       const match = st.description.match(ValueRegex);
-      addMatchToSpan(match, span, impl);
+      addMatchToSpan(match, impl);
     }
   }
 }

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -1,40 +1,28 @@
 // Also see: https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/servertiming.ts
 import { Span } from '@opentelemetry/api';
 import { PerformanceEntries } from '@opentelemetry/sdk-trace-web';
+import OpenTelemetryTracingImpl from './index'
 
-function addMatchToSpan(match: RegExpMatchArray, span: Span): void {
+function addMatchToSpan(match: RegExpMatchArray, span: Span, impl: OpenTelemetryTracingImpl): void {
   if (match && match[1] && match[2]) {
     const traceId = match[1];
     const spanId = match[2];
     span.setAttribute('link.traceId', traceId);
     span.setAttribute('link.spanId', spanId);
-  }
-}
-
-const HeaderRegex = new RegExp('traceparent;desc=[\'"]00-([0-9a-f]{32})-([0-9a-f]{16})-01[\'"]');
-
-export function captureTraceParent(serverTimingValues: string, span: Span): void {
-  // getResponseHeader returns multiple Server-Timing headers concat with ', ' (note space)
-  // fetch returns concat with ','.
-  // split the difference
-  for(let header of serverTimingValues.split(',')) {
-    header = header.trim();
-    const match = header.match(HeaderRegex);
-    addMatchToSpan(match, span);
+    impl.setTraceID(traceId);
   }
 }
 
 const ValueRegex = new RegExp('00-([0-9a-f]{32})-([0-9a-f]{16})-01');
 
-// TODO: fix types for ServerTiming from Performance
-export function captureTraceParentFromPerformanceEntries(entries: PerformanceEntries, span: Span): void {
+export function captureTraceParentFromPerformanceEntries(entries: PerformanceEntries, span: Span, impl: OpenTelemetryTracingImpl): void {
   if (!(entries as any).serverTiming) {
     return;
   }
   for(const st of (entries as any).serverTiming) {
     if (st.name === 'traceparent' && st.description) {
       const match = st.description.match(ValueRegex);
-      addMatchToSpan(match, span);
+      addMatchToSpan(match, span, impl);
     }
   }
 }

--- a/src/impl/servertiming.ts
+++ b/src/impl/servertiming.ts
@@ -6,7 +6,7 @@ function addMatchToSpan(match: RegExpMatchArray, impl: OpenTelemetryTracingImpl)
   if (match && match[1] && match[2]) {
     const traceId = match[1];
     const spanId = match[2];
-    impl.setTransactionTraceId(traceId);
+    if(traceId) impl.setTransactionTraceId(traceId);
   }
 }
 

--- a/src/impl/traceIdGeneration.ts
+++ b/src/impl/traceIdGeneration.ts
@@ -1,0 +1,51 @@
+import { IdGenerator } from '@opentelemetry/core';
+import { RandomIdGenerator } from '@opentelemetry/core';
+import OpenTelemetryTracingImpl from './index'
+
+const SPAN_ID_BYTES = 8;
+const TRACE_ID_BYTES = 16;
+const SHARED_BUFFER = Buffer.allocUnsafe(TRACE_ID_BYTES);
+const impl = new OpenTelemetryTracingImpl();
+
+// Copy of RandomIdGenerator with adjusted functions
+export class CustomIdGenerator implements IdGenerator {
+
+  /**
+   * Returns a random 16-byte trace ID formatted/encoded as a 32 lowercase hex
+   * characters corresponding to 128 bits.
+   */
+  generateTraceId = this.getIdGenerator(TRACE_ID_BYTES);
+
+  /**
+   * Returns a random 8-byte span ID formatted/encoded as a 16 lowercase hex
+   * characters corresponding to 64 bits.
+   */
+  generateSpanId = this.getIdGenerator(SPAN_ID_BYTES);
+
+  getIdGenerator(bytes: number): () => string {
+    return function generateId() {
+
+      console.info("TESTEDI");
+      console.info(impl.getTraceID());
+
+      for (let i = 0; i < bytes / 4; i++) {
+        // unsigned right shift drops decimal part of the number
+        // it is required because if a number between 2**32 and 2**32 - 1 is generated, an out of range error is thrown by writeUInt32BE
+        SHARED_BUFFER.writeUInt32BE((Math.random() * 2 ** 32) >>> 0, i * 4);
+      }
+
+      // If buffer is all 0, set the last byte to 1 to guarantee a valid w3c id is generated
+      for (let i = 0; i < bytes; i++) {
+        if (SHARED_BUFFER[i] > 0) {
+          break;
+        } else if (i === bytes - 1) {
+          SHARED_BUFFER[bytes - 1] = 1;
+        }
+      }
+
+      return SHARED_BUFFER.toString('hex', 0, bytes);
+    };
+  }
+}
+
+

--- a/src/impl/traceIdGeneration.ts
+++ b/src/impl/traceIdGeneration.ts
@@ -10,26 +10,28 @@ const SHARED_BUFFER = Buffer.allocUnsafe(TRACE_ID_BYTES);
 export class CustomIdGenerator implements IdGenerator {
 
   private impl: OpenTelemetryTracingImpl;
-
-  constructor(impl: OpenTelemetryTracingImpl) {
-    this.impl = impl;
-  }
+  private traceID: string;
 
   /**
    * Returns a random 16-byte trace ID formatted/encoded as a 32 lowercase hex
    * characters corresponding to 128 bits.
    */
-  generateTraceId = this.getServerTimingTraceId();
+  generateTraceId: () => string;
 
   /**
    * Returns a random 8-byte span ID formatted/encoded as a 16 lowercase hex
    * characters corresponding to 64 bits.
    */
-  generateSpanId = this.getIdGenerator(SPAN_ID_BYTES);
+  generateSpanId: () => string;
 
+  constructor(impl: OpenTelemetryTracingImpl) {
+    this.impl = impl;
+    this.generateTraceId = this.getServerTimingTraceId();
+    this.generateSpanId = this.getIdGenerator(SPAN_ID_BYTES);
+  }
 
   getServerTimingTraceId(): () => string {
-    const correlationTraceID = this.impl.getTraceID();
+    const correlationTraceID = this.traceID;
 
     // Use Trace-ID from server-timing-header, if existing
     if(correlationTraceID) {
@@ -58,6 +60,8 @@ export class CustomIdGenerator implements IdGenerator {
       return SHARED_BUFFER.toString('hex', 0, bytes);
     };
   }
+
+  public setTraceID(traceID: string): void {
+    this.traceID = traceID;
+  }
 }
-
-

--- a/src/impl/transactionIdGeneration.ts
+++ b/src/impl/transactionIdGeneration.ts
@@ -36,7 +36,7 @@ export class CustomIdGenerator implements IdGenerator {
    */
   getTransactionTraceId(): () => string {
     const transactionTraceId = this.impl.getTransactionTraceId();
-    // Use Trace-ID from server-timing-header, if existing
+    // Use current transaction trace ID, if existing
     if(transactionTraceId) {
       return () => transactionTraceId;
     }

--- a/src/impl/transactionIdGeneration.ts
+++ b/src/impl/transactionIdGeneration.ts
@@ -37,9 +37,7 @@ export class CustomIdGenerator implements IdGenerator {
   getTransactionTraceId(): () => string {
     const transactionTraceId = this.impl.getTransactionTraceId();
     // Use current transaction trace ID, if existing
-    if(transactionTraceId) {
-      return () => transactionTraceId;
-    }
+    if(transactionTraceId) return () => transactionTraceId;
     else return this.getIdGenerator(TRACE_ID_BYTES);
   }
 

--- a/src/impl/transactionIdGeneration.ts
+++ b/src/impl/transactionIdGeneration.ts
@@ -1,5 +1,5 @@
 import { IdGenerator } from '@opentelemetry/core';
-import OpenTelemetryTracingImpl from './index'
+import { TransactionSpanManager } from './transactionSpanManager';
 
 const SPAN_ID_BYTES = 8;
 const TRACE_ID_BYTES = 16;
@@ -7,12 +7,6 @@ const SHARED_BUFFER = Buffer.allocUnsafe(TRACE_ID_BYTES);
 
 // Copy of RandomIdGenerator (@opentelemetry/core) with additional getTransactionTraceId()-function
 export class CustomIdGenerator implements IdGenerator {
-
-  private impl: OpenTelemetryTracingImpl;
-
-  constructor(impl: OpenTelemetryTracingImpl) {
-    this.impl = impl;
-  }
 
   /**
    * Returns a random 16-byte trace ID formatted/encoded as a 32 lowercase hex
@@ -31,11 +25,11 @@ export class CustomIdGenerator implements IdGenerator {
   }
 
   /**
-   * If the OpenTelemetryTracingImpl contains a transaction-trace-id, use it
+   * If there is a transaction-trace-id, use it
    * Otherwise, generate a new trace-id the ordinary way
    */
   getTransactionTraceId(): () => string {
-    const transactionTraceId = this.impl.getTransactionTraceId();
+    const transactionTraceId = TransactionSpanManager.getTransactionTraceId();
     // Use current transaction trace ID, if existing
     if(transactionTraceId) return () => transactionTraceId;
     else return this.getIdGenerator(TRACE_ID_BYTES);

--- a/src/impl/transactionIdGeneration.ts
+++ b/src/impl/transactionIdGeneration.ts
@@ -36,7 +36,7 @@ export class CustomIdGenerator implements IdGenerator {
    */
   getTransactionTraceId(): () => string {
     const transactionTraceId = this.impl.getTransactionTraceId();
-    console.info("TransactionId: " + transactionTraceId)
+    console.info("TransactionTraceId: " + transactionTraceId)
     // Use Trace-ID from server-timing-header, if existing
     if(transactionTraceId) {
       return () => transactionTraceId;

--- a/src/impl/transactionIdGeneration.ts
+++ b/src/impl/transactionIdGeneration.ts
@@ -36,7 +36,6 @@ export class CustomIdGenerator implements IdGenerator {
    */
   getTransactionTraceId(): () => string {
     const transactionTraceId = this.impl.getTransactionTraceId();
-    console.info("TransactionTraceId: " + transactionTraceId)
     // Use Trace-ID from server-timing-header, if existing
     if(transactionTraceId) {
       return () => transactionTraceId;

--- a/src/impl/transactionSpanManager.ts
+++ b/src/impl/transactionSpanManager.ts
@@ -1,0 +1,81 @@
+import api, { Span } from '@opentelemetry/api';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { CustomIdGenerator } from './transactionIdGeneration';
+
+/**
+ * Manager, that stores the transaction-span and provides Getter- and Setter-functions
+ */
+export class TransactionSpanManager {
+
+  private static readonly openTelemetryVersion = "0.25.0";
+  private static readonly documentLoadTracerName = "@opentelemetry/instrumentation-document-load";
+
+  // Store trace-id, before transactionSpan was created
+  private static transactionTraceId: string;
+  // Store span-id, before transactionSpan was created
+  private static transactionSpanId: string;
+  private static transactionSpan: Span;
+
+  // Disabled, by default
+  private static isTransactionRecordingEnabled = false;
+
+  private static idGenerator: CustomIdGenerator;
+
+  public static initialize = (isTransactionRecordingEnabled: boolean,
+                              idGenerator: CustomIdGenerator) => {
+    TransactionSpanManager.isTransactionRecordingEnabled = isTransactionRecordingEnabled;
+    TransactionSpanManager.idGenerator = idGenerator;
+  }
+
+  public static getTransactionTraceId = () => {
+    return TransactionSpanManager.transactionTraceId;
+  }
+
+  public static setTransactionTraceId = (traceId: string) => {
+    if(TransactionSpanManager.isTransactionRecordingEnabled)
+      TransactionSpanManager.transactionTraceId = traceId;
+  }
+
+  public static getTransactionSpanId = () => {
+    return TransactionSpanManager.transactionSpanId;
+  }
+
+  public static setTransactionSpanId = (spanId: string) => {
+    if(TransactionSpanManager.isTransactionRecordingEnabled)
+      TransactionSpanManager.transactionSpanId = spanId;
+  }
+
+  public static getTransactionSpan = () => {
+    return TransactionSpanManager.transactionSpan;
+  }
+
+  public static setTransactionSpan = (span: Span) => {
+    if(TransactionSpanManager.isTransactionRecordingEnabled)
+      TransactionSpanManager.transactionSpan = span;
+  }
+
+  public static startNewTransaction = (spanName: string) => {
+    // Check if transactions should be recorded, otherwise don't start transaction
+    if(!TransactionSpanManager.isTransactionRecordingEnabled) {
+      console.warn("No Transaction started: Transaction recording is disabled");
+      return;
+    }
+
+    const currentTransactionSpan = TransactionSpanManager.getTransactionSpan();
+    if(currentTransactionSpan) TransactionSpanManager.transactionSpan.end();
+    // Delete current transaction span, after closing it
+    TransactionSpanManager.setTransactionSpan(null);
+
+    // Delete current transaction IDs, so the IdGenerator cannot use it
+    TransactionSpanManager.setTransactionTraceId(null);
+    TransactionSpanManager.setTransactionSpanId(null);
+    // Generate new random transaction trace ID
+    const newTraceId = TransactionSpanManager.idGenerator.generateTraceId();
+    TransactionSpanManager.setTransactionTraceId(newTraceId);
+
+    // Just use any existing tracer, for example document-load
+    const tracer = api.trace.getTracer(TransactionSpanManager.documentLoadTracerName, TransactionSpanManager.openTelemetryVersion);
+    const newTransactionSpan = tracer.startSpan(spanName, {root: true});
+    TransactionSpanManager.setTransactionSpan(newTransactionSpan);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,8 @@ if (currentEntriesFn) {
       if(addToBeacon) window.BOOMR.addVar(key, value);
     },
 
+    startNewTransaction: impl.startNewTransaction,
+
     is_complete: () => {
       // This method should determine if the plugin has completed doing what it
       // needs to do and return true if so or false otherwise

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ if (currentEntriesFn) {
       if(addToBeacon) window.BOOMR.addVar(key, value);
     },
 
+    // Starts a new transaction, if document_load.recordTransaction is enabled
     startNewTransaction: impl.startNewTransaction,
 
     is_complete: () => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -33,15 +33,13 @@ export interface OTPluginProperties {
   instrument_fetch: boolean;
   instrument_xhr: boolean;
   instrument_document_load: boolean;
-  instrument_document_load_server_timing: boolean;
   instrument_user_interaction: boolean;
 }
 
 export interface OTPluginConfig {
   instrument_fetch: FetchInstrumentationConfig;
   instrument_xhr: XMLHttpRequestInstrumentationConfig;
-  instrument_document_load: InstrumentationConfig;
-  instrument_document_load_server_timing: DocumentLoadServerTimingInstrumentationConfig;
+  instrument_document_load: DocumentLoadServerTimingInstrumentationConfig;
   instrument_user_interaction: InstrumentationConfig;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,11 +1,9 @@
 import { PropagateTraceHeaderCorsUrls } from '@opentelemetry/sdk-trace-web';
 import { CollectorExporterNodeConfigBase } from '@opentelemetry/exporter-collector';
-import {FetchInstrumentation, FetchInstrumentationConfig} from "@opentelemetry/instrumentation-fetch";
-import {
-  XMLHttpRequestInstrumentation,
-  XMLHttpRequestInstrumentationConfig
-} from "@opentelemetry/instrumentation-xml-http-request";
-import {InstrumentationConfig} from "@opentelemetry/instrumentation";
+import { FetchInstrumentationConfig } from "@opentelemetry/instrumentation-fetch";
+import { XMLHttpRequestInstrumentationConfig } from "@opentelemetry/instrumentation-xml-http-request";
+import { DocumentLoadServerTimingInstrumentationConfig } from './impl/documentLoadInstrumentation';
+import { InstrumentationConfig } from "@opentelemetry/instrumentation";
 
 export interface PluginProperties {
   samplingRate: number;
@@ -35,6 +33,7 @@ export interface OTPluginProperties {
   instrument_fetch: boolean;
   instrument_xhr: boolean;
   instrument_document_load: boolean;
+  instrument_document_load_server_timing: boolean;
   instrument_user_interaction: boolean;
 }
 
@@ -42,6 +41,7 @@ export interface OTPluginConfig {
   instrument_fetch: FetchInstrumentationConfig;
   instrument_xhr: XMLHttpRequestInstrumentationConfig;
   instrument_document_load: InstrumentationConfig;
+  instrument_document_load_server_timing: DocumentLoadServerTimingInstrumentationConfig;
   instrument_user_interaction: InstrumentationConfig;
 }
 


### PR DESCRIPTION
Read the traceparent form server timing header if existing and use it to create a transaction span. This span works as a root span for every other span created during this transaction. 

The transaction span will be open until the page will unload or startNewTransaction() will be called.

The function startNewTransaktion() closes the current transaction span and starts a new one.